### PR TITLE
[CU-86eu0bxyh] Integrate to support the retry mechanism for the Slack operations into MCP and webhook servers

### DIFF
--- a/scripts/docker/run-slack-mcp-server.sh
+++ b/scripts/docker/run-slack-mcp-server.sh
@@ -13,6 +13,7 @@ set -e
 # MCP_ENV_FILE → --env-file
 # MCP_NO_ENV_FILE → --no-env-file
 # MCP_INTEGRATED → --integrated
+# MCP_RETRY → --retry
 #
 
 # Initialize command line arguments array
@@ -63,6 +64,11 @@ fi
 # INTEGRATED: Run in integrated mode with webhook server
 if [ -n "${MCP_INTEGRATED}" ] && [ "${MCP_INTEGRATED}" = "true" ]; then
   CMD_ARGS+=(--integrated)
+fi
+
+# RETRY: Number of retry attempts for network operations
+if [ -n "${MCP_RETRY}" ]; then
+  CMD_ARGS+=(--retry "${MCP_RETRY}")
 fi
 
 # Print the command that will be executed

--- a/scripts/docker/run-slack-webhook-server.sh
+++ b/scripts/docker/run-slack-webhook-server.sh
@@ -13,6 +13,7 @@ set -e
 # SLACK_WEBHOOK_INTEGRATED → --integrated
 # SLACK_WEBHOOK_MCP_TRANSPORT → --mcp-transport
 # SLACK_WEBHOOK_MCP_MOUNT_PATH → --mcp-mount-path
+# SLACK_WEBHOOK_RETRY → --retry
 #
 
 # Initialize command line arguments array
@@ -63,6 +64,11 @@ if [ -n "${SLACK_WEBHOOK_INTEGRATED}" ] && [ "${SLACK_WEBHOOK_INTEGRATED}" = "tr
   if [ -n "${SLACK_WEBHOOK_MCP_MOUNT_PATH}" ]; then
     CMD_ARGS+=(--mcp-mount-path "${SLACK_WEBHOOK_MCP_MOUNT_PATH}")
   fi
+fi
+
+# RETRY: Number of retry attempts for network operations
+if [ -n "${SLACK_WEBHOOK_RETRY}" ]; then
+  CMD_ARGS+=(--retry "${SLACK_WEBHOOK_RETRY}")
 fi
 
 # Print the command that will be executed

--- a/slack_mcp/entry.py
+++ b/slack_mcp/entry.py
@@ -12,7 +12,8 @@ import uvicorn
 from dotenv import load_dotenv
 
 from .integrated_server import create_integrated_app
-from .server import mcp as _server_instance, set_slack_client_retry_count
+from .server import mcp as _server_instance
+from .server import set_slack_client_retry_count
 
 _LOG: Final[logging.Logger] = logging.getLogger("slack_mcp.entry")
 
@@ -104,13 +105,11 @@ def main(argv: list[str] | None = None) -> None:  # noqa: D401 – CLI entry
 
         # Create integrated app with both MCP and webhook functionality
         app = create_integrated_app(
-            token=args.slack_token, 
-            mcp_transport=args.transport, 
-            mcp_mount_path=args.mount_path,
-            retry=args.retry
+            token=args.slack_token, mcp_transport=args.transport, mcp_mount_path=args.mount_path, retry=args.retry
         )
-        from .slack_app import slack_client
         from .server import update_slack_client
+        from .slack_app import slack_client
+
         update_slack_client(token=args.slack_token, client=slack_client)
 
         # Run the integrated FastAPI app

--- a/slack_mcp/entry.py
+++ b/slack_mcp/entry.py
@@ -12,7 +12,7 @@ import uvicorn
 from dotenv import load_dotenv
 
 from .integrated_server import create_integrated_app
-from .server import mcp as _server_instance
+from .server import mcp as _server_instance, set_slack_client_retry_count
 
 _LOG: Final[logging.Logger] = logging.getLogger("slack_mcp.entry")
 
@@ -66,6 +66,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: D
         action="store_true",
         help="Run MCP server integrated with webhook server in a single FastAPI application",
     )
+    parser.add_argument(
+        "--retry",
+        type=int,
+        default=3,
+        help="Number of retry attempts for network operations (default: 3)",
+    )
     return parser.parse_args(argv)
 
 
@@ -98,12 +104,21 @@ def main(argv: list[str] | None = None) -> None:  # noqa: D401 – CLI entry
 
         # Create integrated app with both MCP and webhook functionality
         app = create_integrated_app(
-            token=args.slack_token, mcp_transport=args.transport, mcp_mount_path=args.mount_path
+            token=args.slack_token, 
+            mcp_transport=args.transport, 
+            mcp_mount_path=args.mount_path,
+            retry=args.retry
         )
+        from .slack_app import slack_client
+        from .server import update_slack_client
+        update_slack_client(token=args.slack_token, client=slack_client)
 
         # Run the integrated FastAPI app
         uvicorn.run(app, host=args.host, port=args.port)
     else:
+        if args.retry:
+            set_slack_client_retry_count(retry=args.retry)
+
         _LOG.info("Starting Slack MCP server: transport=%s", args.transport)
 
         if args.transport in ["sse", "streamable-http"]:

--- a/slack_mcp/integrated_server.py
+++ b/slack_mcp/integrated_server.py
@@ -25,6 +25,7 @@ def create_integrated_app(
     token: Optional[str] = None,
     mcp_transport: str = "sse",
     mcp_mount_path: Optional[str] = "/mcp",
+    retry: int = 3,
 ) -> FastAPI:
     """Create an integrated FastAPI app with both MCP and webhook functionalities.
 
@@ -39,6 +40,8 @@ def create_integrated_app(
         The transport to use for the MCP server. Either "sse" or "streamable-http".
     mcp_mount_path : Optional[str]
         The path to mount the MCP server on. Only relevant for "sse" transport.
+    retry : int
+        Number of retry attempts for network operations (default: 3).
 
     Returns
     -------
@@ -57,7 +60,7 @@ def create_integrated_app(
         )
 
     # Create the webhook app first
-    app = create_slack_app(token)
+    app = create_slack_app(token, retry=retry)
 
     # Get the appropriate MCP app based on the transport
     if mcp_transport == "sse":

--- a/slack_mcp/server.py
+++ b/slack_mcp/server.py
@@ -8,22 +8,14 @@ applications or test-suites may interact with the exported ``mcp`` instance.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Final, List
+import logging
+import os
+from typing import Any, Dict, Final, List, Optional
 
 from mcp.server.fastmcp import FastMCP
 from slack_sdk.web.async_client import AsyncWebClient
 
-__all__: list[str] = [
-    "mcp",
-    "send_slack_message",
-    "read_thread_messages",
-    "read_slack_channel_messages",
-    "send_slack_thread_reply",
-    "read_slack_emojis",
-    "add_slack_reactions",
-]
-
-from slack_mcp.client_factory import default_factory
+from slack_mcp.client_factory import RetryableSlackClientFactory
 from slack_mcp.model import (
     SlackAddReactionsInput,
     SlackPostMessageInput,
@@ -34,14 +26,144 @@ from slack_mcp.model import (
     _BaseInput,
 )
 
+__all__: list[str] = [
+    "mcp",
+    "send_slack_message",
+    "read_thread_messages",
+    "read_slack_channel_messages",
+    "send_slack_thread_reply",
+    "read_slack_emojis",
+    "add_slack_reactions",
+    "set_slack_client_retry_count",
+    "get_slack_client",
+    "clear_slack_clients",
+    "update_slack_client",
+]
+
 # A single FastMCP server instance to be discovered by the MCP runtime.
 SERVER_NAME: Final[str] = "SlackMCPServer"
 
+# Logger for this module
+_LOG: Final[logging.Logger] = logging.getLogger("slack_mcp.server")
+
+# Global setting for Slack client retry count
+_slack_client_retry_count: int = 3
+
+# Global retryable factory for Slack clients
+_retryable_factory = RetryableSlackClientFactory(max_retry_count=_slack_client_retry_count)
+
+# Client cache for singleton pattern - keyed by token
+_slack_clients: Dict[str, AsyncWebClient] = {}
+
+# Default token from environment
+_DEFAULT_TOKEN = os.environ.get("SLACK_BOT_TOKEN") or os.environ.get("SLACK_TOKEN")
+
 mcp: Final[FastMCP] = FastMCP(name=SERVER_NAME)
 
+def set_slack_client_retry_count(retry: int) -> None:
+    """Set the retry count for Slack web client operations.
+
+    This only affects the Slack API client's built-in retry mechanism
+    and does not alter the core MCP server logic.
+
+    Parameters
+    ----------
+    retry : int
+        Number of retry attempts for Slack API operations
+    """
+    global _slack_client_retry_count, _retryable_factory, _slack_clients
+    _slack_client_retry_count = retry
+    _retryable_factory = RetryableSlackClientFactory(max_retry_count=retry)
+    
+    # Clear client cache when retry count changes to ensure all future clients 
+    # use the new retry settings
+    _slack_clients.clear()
+    _LOG.info(f"Slack client retry count set to {retry} and client cache cleared")
+
+def get_slack_client(token: Optional[str] = None) -> AsyncWebClient:
+    """Get or create a Slack client with the specified token.
+    
+    Uses a singleton pattern to avoid creating multiple clients for the same token.
+    
+    Parameters
+    ----------
+    token : Optional[str]
+        The Slack token to use. If None, will use environment variables.
+        
+    Returns
+    -------
+    AsyncWebClient
+        The Slack client
+        
+    Raises
+    ------
+    ValueError
+        If no token is found or provided
+    """
+    global _slack_clients
+    
+    # Resolve token
+    resolved_token = token or _DEFAULT_TOKEN
+    if not resolved_token:
+        raise ValueError(
+            "Slack token not found. Provide one via the parameter or set "
+            "the SLACK_BOT_TOKEN/SLACK_TOKEN environment variable."
+        )
+    
+    # Return cached client if exists
+    if resolved_token in _slack_clients:
+        return _slack_clients[resolved_token]
+    
+    # Create new client
+    if _slack_client_retry_count > 0:
+        client = _retryable_factory.create_async_client(resolved_token)
+    else:
+        client = AsyncWebClient(token=resolved_token)
+    
+    # Cache the client
+    _slack_clients[resolved_token] = client
+    _LOG.debug(f"Created new Slack client for token ending with ...{resolved_token[-4:]}")
+    
+    return client
+
+def clear_slack_clients() -> None:
+    """Clear the Slack client cache.
+    
+    This forces new clients to be created on the next request.
+    """
+    global _slack_clients
+    _slack_clients.clear()
+    _LOG.info("Slack client cache cleared")
+
+def update_slack_client(token: str, client: AsyncWebClient) -> None:
+    """Update or add a Slack client in the global cache.
+    
+    This allows replacing an existing client with a custom-configured one
+    or adding a new client with specific configurations.
+    
+    Parameters
+    ----------
+    token : str
+        The token associated with this client
+    client : AsyncWebClient
+        The Slack client instance to cache
+        
+    Raises
+    ------
+    ValueError
+        If the token is empty or None
+    """
+    if not token:
+        raise ValueError("Token cannot be empty or None")
+        
+    global _slack_clients
+    _slack_clients[token] = client
+    _LOG.info(f"Updated Slack client for token ending with ...{token[-4:]}")
 
 def _get_web_client(input_params: _BaseInput) -> AsyncWebClient:
-    """Create and return an AsyncWebClient instance with the resolved token.
+    """Get or create an AsyncWebClient instance with the resolved token.
+
+    Uses singleton pattern to reuse existing clients when possible.
 
     Parameters
     ----------
@@ -58,8 +180,9 @@ def _get_web_client(input_params: _BaseInput) -> AsyncWebClient:
     ValueError
         If no token is supplied and the relevant environment variables are missing.
     """
-    return default_factory.create_async_client_from_input(input_params)
-
+    # Extract token from input params if available
+    token = getattr(input_params, "token", None)
+    return get_slack_client(token)
 
 @mcp.tool("slack_post_message")
 async def send_slack_message(

--- a/slack_mcp/slack_app.py
+++ b/slack_mcp/slack_app.py
@@ -34,6 +34,7 @@ _LOG: Final[logging.Logger] = logging.getLogger("slack_mcp.slack_app")
 # Global Slack client for common usage outside of this module
 slack_client: Optional[AsyncWebClient] = None
 
+
 def initialize_slack_client(token: str | None = None, retry: int = 0) -> AsyncWebClient:
     """Initialize the global Slack client.
 
@@ -79,17 +80,18 @@ def initialize_slack_client(token: str | None = None, retry: int = 0) -> AsyncWe
         # This uses Slack SDK's built-in retry handlers for rate limits, server errors, etc.
         client_factory = RetryableSlackClientFactory(max_retry_count=retry)
         slack_client = client_factory.create_async_client(resolved_token)
-    
+
     return slack_client
+
 
 def get_slack_client() -> AsyncWebClient:
     """Get the global Slack client.
-    
+
     Returns
     -------
     AsyncWebClient
         The global Slack client
-    
+
     Raises
     ------
     ValueError
@@ -98,6 +100,7 @@ def get_slack_client() -> AsyncWebClient:
     if slack_client is None:
         raise ValueError("Slack client not initialized. Call initialize_slack_client first.")
     return slack_client
+
 
 async def verify_slack_request(request: Request, signing_secret: str | None = None) -> bool:
     """Verify that the request is coming from Slack.

--- a/slack_mcp/slack_app.py
+++ b/slack_mcp/slack_app.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Dict, Final, cast
+from typing import Any, Dict, Final, Optional, cast
 
 from fastapi import FastAPI, HTTPException, Request, Response, status
 from fastapi.responses import JSONResponse
@@ -24,10 +24,80 @@ __all__: list[str] = [
     "create_slack_app",
     "verify_slack_request",
     "handle_slack_event",
+    "slack_client",
+    "get_slack_client",
+    "initialize_slack_client",
 ]
 
 _LOG: Final[logging.Logger] = logging.getLogger("slack_mcp.slack_app")
 
+# Global Slack client for common usage outside of this module
+slack_client: Optional[AsyncWebClient] = None
+
+def initialize_slack_client(token: str | None = None, retry: int = 0) -> AsyncWebClient:
+    """Initialize the global Slack client.
+
+    Parameters
+    ----------
+    token : str | None
+        The Slack bot token to use. If None, will use SLACK_BOT_TOKEN env var.
+    retry : int
+        Number of retry attempts for Slack API operations (default: 0).
+        If set to 0, no retry mechanism is used.
+        If set to a positive value, uses Slack SDK's built-in retry handlers
+        for rate limits, server errors, and connection issues.
+
+    Returns
+    -------
+    AsyncWebClient
+        The initialized Slack client
+
+    Raises
+    ------
+    ValueError
+        If no token is found (either from parameter or environment variables)
+        or if retry count is negative.
+    """
+    global slack_client
+
+    # Resolve token
+    resolved_token = token or os.environ.get("SLACK_BOT_TOKEN") or os.environ.get("SLACK_TOKEN")
+    if not resolved_token:
+        raise ValueError(
+            "Slack token not found. Provide one via the 'token' parameter or set "
+            "the SLACK_BOT_TOKEN/SLACK_TOKEN environment variable."
+        )
+
+    # Create Slack client
+    if retry < 0:
+        raise ValueError("Retry count must be non-negative")
+
+    if retry == 0:
+        slack_client = AsyncWebClient(token=resolved_token)
+    else:
+        # Create Slack client with retry capability using the RetryableSlackClientFactory
+        # This uses Slack SDK's built-in retry handlers for rate limits, server errors, etc.
+        client_factory = RetryableSlackClientFactory(max_retry_count=retry)
+        slack_client = client_factory.create_async_client(resolved_token)
+    
+    return slack_client
+
+def get_slack_client() -> AsyncWebClient:
+    """Get the global Slack client.
+    
+    Returns
+    -------
+    AsyncWebClient
+        The global Slack client
+    
+    Raises
+    ------
+    ValueError
+        If the client has not been initialized
+    """
+    if slack_client is None:
+        raise ValueError("Slack client not initialized. Call initialize_slack_client first.")
+    return slack_client
 
 async def verify_slack_request(request: Request, signing_secret: str | None = None) -> bool:
     """Verify that the request is coming from Slack.
@@ -128,25 +198,8 @@ def create_slack_app(token: str | None = None, retry: int = 0) -> FastAPI:
     """
     app = FastAPI(title="Slack MCP Server")
 
-    # Resolve token
-    resolved_token = token or os.environ.get("SLACK_BOT_TOKEN") or os.environ.get("SLACK_TOKEN")
-    if not resolved_token:
-        raise ValueError(
-            "Slack token not found. Provide one via the 'token' parameter or set "
-            "the SLACK_BOT_TOKEN/SLACK_TOKEN environment variable."
-        )
-
-    # Create Slack client
-    if retry < 0:
-        raise ValueError("Retry count must be non-negative")
-
-    if retry == 0:
-        client = AsyncWebClient(token=resolved_token)
-    else:
-        # Create Slack client with retry capability using the RetryableSlackClientFactory
-        # This uses Slack SDK's built-in retry handlers for rate limits, server errors, etc.
-        client_factory = RetryableSlackClientFactory(max_retry_count=retry)
-        client = client_factory.create_async_client(resolved_token)
+    # Initialize the global Slack client
+    client = initialize_slack_client(token, retry)
 
     @app.post("/slack/events")
     async def slack_events(request: Request) -> Response:

--- a/test/integration_test/test_env_loading_webhook.py
+++ b/test/integration_test/test_env_loading_webhook.py
@@ -36,7 +36,7 @@ def test_webhook_dotenv_loading_with_valid_env_file():
 
                         # Verify that run_slack_server was called with the default host/port
                         mock_run.assert_called_once()
-                        mock_server_run.assert_called_once_with(host="0.0.0.0", port=3000, token=None)
+                        mock_server_run.assert_called_once_with(host="0.0.0.0", port=3000, token=None, retry=3)
 
     finally:
         # Clean up the temporary file
@@ -62,7 +62,7 @@ def test_webhook_cmd_line_token_passed_to_server():
 
                     # Verify that run_slack_server was called with the token
                     mock_run.assert_called_once()
-                    mock_server_run.assert_called_once_with(host="0.0.0.0", port=3000, token=cmd_line_token)
+                    mock_server_run.assert_called_once_with(host="0.0.0.0", port=3000, token=cmd_line_token, retry=3)
 
 
 def test_webhook_create_slack_app_with_env_token():

--- a/test/unit_test/test_entry.py
+++ b/test/unit_test/test_entry.py
@@ -74,7 +74,7 @@ def _patch_entry(monkeypatch: pytest.MonkeyPatch) -> Generator[SimpleNamespace, 
     mock_integrated_app = SimpleNamespace()
     monkeypatch.setattr(
         "slack_mcp.entry.create_integrated_app",
-        lambda token=None, mcp_transport=None, mcp_mount_path=None: mock_integrated_app,
+        lambda token=None, mcp_transport=None, mcp_mount_path=None, retry=0: mock_integrated_app,
     )
 
     # Re-import the module to update bindings

--- a/test/unit_test/test_integrated_server.py
+++ b/test/unit_test/test_integrated_server.py
@@ -54,7 +54,7 @@ def mock_dependencies(monkeypatch: pytest.MonkeyPatch) -> Dict[str, Any]:
 
     # Mock the server imports
     monkeypatch.setattr("slack_mcp.integrated_server._server_instance", mock_mcp)
-    monkeypatch.setattr("slack_mcp.integrated_server.create_slack_app", lambda token=None: mock_webhook_app)
+    monkeypatch.setattr("slack_mcp.integrated_server.create_slack_app", lambda token=None, retry=3: mock_webhook_app)
 
     return {
         "mock_mcp": mock_mcp,

--- a/test/unit_test/test_slack_app_client.py
+++ b/test/unit_test/test_slack_app_client.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import os
-from typing import Generator, Optional
+from typing import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -18,12 +17,12 @@ def clean_global_client() -> Generator[None, None, None]:
     """Reset the global slack_client variable after each test."""
     # Save original
     original_client = slack_app.slack_client
-    
+
     # Reset for test
     slack_app.slack_client = None
-    
+
     yield
-    
+
     # Restore original
     slack_app.slack_client = original_client
 
@@ -37,11 +36,11 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 class TestInitializeSlackClient:
     """Tests for initialize_slack_client function."""
-    
+
     def test_initialize_with_explicit_token(self, clean_global_client: None) -> None:
         """Should initialize client with explicitly provided token."""
         client: AsyncWebClient = slack_app.initialize_slack_client(token="test-token-123")
-        
+
         assert isinstance(client, AsyncWebClient)
         assert client.token == "test-token-123"
         assert slack_app.slack_client is client  # Global variable should be set
@@ -49,31 +48,35 @@ class TestInitializeSlackClient:
     def test_initialize_with_bot_token_env(self, clean_global_client: None, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should use SLACK_BOT_TOKEN from environment when no token provided."""
         monkeypatch.setenv("SLACK_BOT_TOKEN", "env-bot-token")
-        
+
         client: AsyncWebClient = slack_app.initialize_slack_client()
-        
+
         assert client.token == "env-bot-token"
         assert slack_app.slack_client is client
 
-    def test_initialize_with_fallback_token_env(self, clean_global_client: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_initialize_with_fallback_token_env(
+        self, clean_global_client: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Should use SLACK_TOKEN from environment when no SLACK_BOT_TOKEN or explicit token provided."""
         monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
         monkeypatch.setenv("SLACK_TOKEN", "fallback-token")
-        
+
         client: AsyncWebClient = slack_app.initialize_slack_client()
-        
+
         assert client.token == "fallback-token"
         assert slack_app.slack_client is client
 
-    def test_initialize_token_resolution_priority(self, clean_global_client: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_initialize_token_resolution_priority(
+        self, clean_global_client: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Should prioritize explicit token over environment variables."""
         # Set both environment variables
         monkeypatch.setenv("SLACK_BOT_TOKEN", "env-bot-token")
         monkeypatch.setenv("SLACK_TOKEN", "fallback-token")
-        
+
         # Provide explicit token
         client: AsyncWebClient = slack_app.initialize_slack_client(token="explicit-token")
-        
+
         # Explicit token should take precedence
         assert client.token == "explicit-token"
 
@@ -81,7 +84,7 @@ class TestInitializeSlackClient:
         """Should raise ValueError when no token is available."""
         with pytest.raises(ValueError) as excinfo:
             slack_app.initialize_slack_client()
-        
+
         assert "Slack token not found" in str(excinfo.value)
         assert slack_app.slack_client is None  # Global variable should remain None
 
@@ -89,14 +92,14 @@ class TestInitializeSlackClient:
         """Should raise ValueError when retry count is negative."""
         with pytest.raises(ValueError) as excinfo:
             slack_app.initialize_slack_client(token="test-token", retry=-1)
-        
+
         assert "Retry count must be non-negative" in str(excinfo.value)
         assert slack_app.slack_client is None  # Global variable should remain None
 
     def test_initialize_with_zero_retry(self, clean_global_client: None) -> None:
         """Should create standard client when retry=0."""
         client: AsyncWebClient = slack_app.initialize_slack_client(token="test-token", retry=0)
-        
+
         assert isinstance(client, AsyncWebClient)
         # The default AsyncWebClient may have some built-in retry handlers regardless of our retry setting
         # We're just checking it was created correctly without using RetryableSlackClientFactory
@@ -107,10 +110,10 @@ class TestInitializeSlackClient:
         mock_client = MagicMock(spec=AsyncWebClient)
         mock_factory = MagicMock(spec=RetryableSlackClientFactory)
         mock_factory.create_async_client.return_value = mock_client
-        
+
         with patch("slack_mcp.slack_app.RetryableSlackClientFactory", return_value=mock_factory):
             client = slack_app.initialize_slack_client(token="test-token", retry=3)
-        
+
         # Verify factory was created with correct retry count
         assert client is mock_client
         mock_factory.create_async_client.assert_called_once_with("test-token")
@@ -119,10 +122,10 @@ class TestInitializeSlackClient:
         """Should replace existing global client when called multiple times."""
         # Initialize first client
         first_client = slack_app.initialize_slack_client(token="first-token")
-        
+
         # Initialize second client
         second_client = slack_app.initialize_slack_client(token="second-token")
-        
+
         # Second client should replace the first one
         assert slack_app.slack_client is second_client
         assert slack_app.slack_client is not first_client
@@ -131,15 +134,15 @@ class TestInitializeSlackClient:
 
 class TestGetSlackClient:
     """Tests for get_slack_client function."""
-    
+
     def test_get_initialized_client(self, clean_global_client: None) -> None:
         """Should return the initialized client."""
         # Initialize client first
         initialized_client = slack_app.initialize_slack_client(token="test-token")
-        
+
         # Get client
         client = slack_app.get_slack_client()
-        
+
         # Should be the same instance
         assert client is initialized_client
         assert client is slack_app.slack_client
@@ -148,23 +151,23 @@ class TestGetSlackClient:
         """Should raise ValueError when client is not initialized."""
         # Ensure client is None
         assert slack_app.slack_client is None
-        
+
         # Should raise ValueError
         with pytest.raises(ValueError) as excinfo:
             slack_app.get_slack_client()
-        
+
         assert "Slack client not initialized" in str(excinfo.value)
 
     def test_get_client_after_reinitialization(self, clean_global_client: None) -> None:
         """Should return the most recently initialized client."""
         # Initialize first client
         slack_app.initialize_slack_client(token="first-token")
-        
+
         # Initialize second client
         second_client = slack_app.initialize_slack_client(token="second-token")
-        
+
         # Get client - should be second one
         client = slack_app.get_slack_client()
-        
+
         assert client is second_client
         assert client.token == "second-token"

--- a/test/unit_test/test_slack_client_utils.py
+++ b/test/unit_test/test_slack_client_utils.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import os
-from typing import Any, Generator, Optional
-from unittest.mock import MagicMock, Mock, patch
+from typing import Generator, Optional
+from unittest.mock import MagicMock
 
 import pytest
 from slack_sdk.web.async_client import AsyncWebClient
@@ -28,12 +27,12 @@ def reset_slack_clients() -> Generator[None, None, None]:
     original_retry_count: int = srv._slack_client_retry_count
     original_factory: RetryableSlackClientFactory = srv._retryable_factory
     original_default_token: Optional[str] = srv._DEFAULT_TOKEN
-    
+
     # Clear for test
     srv._slack_clients.clear()
-    
+
     yield
-    
+
     # Restore original values
     srv._slack_clients = original_clients
     srv._slack_client_retry_count = original_retry_count
@@ -48,10 +47,10 @@ class TestGetSlackClient:
         """Should create a new client when provided a token."""
         # First, verify the cache is empty
         assert len(srv._slack_clients) == 0
-        
+
         # Call with explicit token
         client: AsyncWebClient = srv.get_slack_client("test-token-123")
-        
+
         # Check results - a client was created and cached
         assert isinstance(client, AsyncWebClient)
         assert client.token == "test-token-123"  # AsyncWebClient stores the token
@@ -63,7 +62,7 @@ class TestGetSlackClient:
         # Call twice with same token
         client1: AsyncWebClient = srv.get_slack_client("test-token-123")
         client2: AsyncWebClient = srv.get_slack_client("test-token-123")
-        
+
         # Should return the exact same object
         assert client1 is client2
         assert len(srv._slack_clients) == 1
@@ -73,7 +72,7 @@ class TestGetSlackClient:
         # Call with different tokens
         client1: AsyncWebClient = srv.get_slack_client("token1")
         client2: AsyncWebClient = srv.get_slack_client("token2")
-        
+
         # Should be different objects with correct tokens
         assert client1 is not client2
         assert client1.token == "token1"
@@ -86,14 +85,14 @@ class TestGetSlackClient:
         mock_factory: MagicMock = MagicMock(spec=RetryableSlackClientFactory)
         mock_client: MagicMock = MagicMock(spec=AsyncWebClient)
         mock_factory.create_async_client.return_value = mock_client
-        
+
         # Setup server module
         srv._slack_client_retry_count = 5
         srv._retryable_factory = mock_factory
-        
+
         # Call get_slack_client
         client: AsyncWebClient = srv.get_slack_client("test-token")
-        
+
         # Verify factory was used
         mock_factory.create_async_client.assert_called_once_with("test-token")
         assert client is mock_client
@@ -101,15 +100,15 @@ class TestGetSlackClient:
 
     def test_get_client_from_env(self, reset_slack_clients: None, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should fall back to environment variables when token is None."""
-        # Set environment variable 
+        # Set environment variable
         monkeypatch.setenv("SLACK_BOT_TOKEN", "env-token-123")
-        
+
         # Update _DEFAULT_TOKEN which is calculated at module import time
         srv._DEFAULT_TOKEN = "env-token-123"
-        
+
         # Call get_slack_client with no token
         client: AsyncWebClient = srv.get_slack_client()
-        
+
         # Verify correct token was used
         assert client.token == "env-token-123"
         assert "env-token-123" in srv._slack_clients
@@ -121,13 +120,13 @@ class TestGetSlackClient:
         # Set only SLACK_TOKEN
         monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
         monkeypatch.setenv("SLACK_TOKEN", "fallback-token")
-        
+
         # Directly set the cached token value
         srv._DEFAULT_TOKEN = "fallback-token"
-        
+
         # Call with no token
         client: AsyncWebClient = srv.get_slack_client()
-        
+
         # Verify correct token was used
         assert client.token == "fallback-token"
         assert "fallback-token" in srv._slack_clients
@@ -136,26 +135,26 @@ class TestGetSlackClient:
         """Should raise ValueError when no token is available."""
         # Set _DEFAULT_TOKEN to None to simulate no env vars
         srv._DEFAULT_TOKEN = None
-        
+
         # Should raise ValueError
         with pytest.raises(ValueError) as excinfo:
             srv.get_slack_client()
-        
+
         # Check error message
         assert "Slack token not found" in str(excinfo.value)
 
 
 class TestClearSlackClients:
     """Tests for clear_slack_clients function."""
-    
+
     def test_clear_empty_cache(self, reset_slack_clients: None) -> None:
         """Should handle clearing an already empty cache."""
         # Start with empty cache
         assert len(srv._slack_clients) == 0
-        
+
         # Clear
         srv.clear_slack_clients()
-        
+
         # Still empty
         assert len(srv._slack_clients) == 0
 
@@ -165,10 +164,10 @@ class TestClearSlackClients:
         srv._slack_clients["token1"] = AsyncWebClient(token="token1")
         srv._slack_clients["token2"] = AsyncWebClient(token="token2")
         assert len(srv._slack_clients) == 2
-        
+
         # Clear
         srv.clear_slack_clients()
-        
+
         # Verify empty
         assert len(srv._slack_clients) == 0
 
@@ -176,13 +175,13 @@ class TestClearSlackClients:
         """Should force creation of new clients after clearing."""
         # Create initial client
         client1: AsyncWebClient = srv.get_slack_client("test-token")
-        
+
         # Clear cache
         srv.clear_slack_clients()
-        
+
         # Get client again
         client2: AsyncWebClient = srv.get_slack_client("test-token")
-        
+
         # Should be different objects
         assert client1 is not client2
         assert client1.token == client2.token
@@ -190,15 +189,15 @@ class TestClearSlackClients:
 
 class TestUpdateSlackClient:
     """Tests for update_slack_client function."""
-    
+
     def test_update_new_client(self, reset_slack_clients: None) -> None:
         """Should add a new client to the cache."""
         # Create client
         custom_client: AsyncWebClient = AsyncWebClient(token="custom-token")
-        
+
         # Update cache
         srv.update_slack_client("custom-token", custom_client)
-        
+
         # Verify in cache
         assert "custom-token" in srv._slack_clients
         assert srv._slack_clients["custom-token"] is custom_client
@@ -208,13 +207,13 @@ class TestUpdateSlackClient:
         # Add client to cache
         original_client: AsyncWebClient = AsyncWebClient(token="test-token")
         srv._slack_clients["test-token"] = original_client
-        
+
         # Create replacement
         replacement_client: AsyncWebClient = AsyncWebClient(token="test-token")
-        
+
         # Update cache
         srv.update_slack_client("test-token", replacement_client)
-        
+
         # Verify replacement
         assert srv._slack_clients["test-token"] is replacement_client
         assert srv._slack_clients["test-token"] is not original_client
@@ -222,12 +221,12 @@ class TestUpdateSlackClient:
     def test_update_with_empty_token_raises_error(self, reset_slack_clients: None) -> None:
         """Should raise ValueError when token is empty."""
         client: AsyncWebClient = AsyncWebClient(token="valid-token")
-        
+
         # Empty string token
         with pytest.raises(ValueError) as excinfo:
             srv.update_slack_client("", client)
         assert "Token cannot be empty" in str(excinfo.value)
-        
+
         # None token
         with pytest.raises(ValueError):
             # We need to ignore the type error since we're testing runtime behavior
@@ -241,11 +240,11 @@ class TestSetSlackClientRetryCount:
         """Should update the retry count and factory."""
         # Initial value
         initial_count: int = srv._slack_client_retry_count
-        
+
         # Set to new value
         test_count: int = initial_count + 5  # Ensure different
         srv.set_slack_client_retry_count(test_count)
-        
+
         # Verify updated
         assert srv._slack_client_retry_count == test_count
         assert srv._retryable_factory.max_retry_count == test_count
@@ -256,9 +255,9 @@ class TestSetSlackClientRetryCount:
         srv._slack_clients["token1"] = AsyncWebClient(token="token1")
         srv._slack_clients["token2"] = AsyncWebClient(token="token2")
         assert len(srv._slack_clients) == 2
-        
+
         # Set retry count
         srv.set_slack_client_retry_count(10)
-        
+
         # Verify cache cleared
         assert len(srv._slack_clients) == 0

--- a/test/unit_test/test_slack_client_utils.py
+++ b/test/unit_test/test_slack_client_utils.py
@@ -1,0 +1,264 @@
+"""Unit tests for Slack client utility functions in server.py."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Generator, Optional
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from slack_sdk.web.async_client import AsyncWebClient
+
+from slack_mcp import server as srv
+from slack_mcp.client_factory import RetryableSlackClientFactory
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove Slack token environment variables."""
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("SLACK_TOKEN", raising=False)
+
+
+@pytest.fixture
+def reset_slack_clients() -> Generator[None, None, None]:
+    """Reset all slack client globals after each test."""
+    # Save original values
+    original_clients: dict[str, AsyncWebClient] = srv._slack_clients.copy()
+    original_retry_count: int = srv._slack_client_retry_count
+    original_factory: RetryableSlackClientFactory = srv._retryable_factory
+    original_default_token: Optional[str] = srv._DEFAULT_TOKEN
+    
+    # Clear for test
+    srv._slack_clients.clear()
+    
+    yield
+    
+    # Restore original values
+    srv._slack_clients = original_clients
+    srv._slack_client_retry_count = original_retry_count
+    srv._retryable_factory = original_factory
+    srv._DEFAULT_TOKEN = original_default_token
+
+
+class TestGetSlackClient:
+    """Tests for get_slack_client function."""
+
+    def test_get_client_with_explicit_token(self, reset_slack_clients: None) -> None:
+        """Should create a new client when provided a token."""
+        # First, verify the cache is empty
+        assert len(srv._slack_clients) == 0
+        
+        # Call with explicit token
+        client: AsyncWebClient = srv.get_slack_client("test-token-123")
+        
+        # Check results - a client was created and cached
+        assert isinstance(client, AsyncWebClient)
+        assert client.token == "test-token-123"  # AsyncWebClient stores the token
+        assert len(srv._slack_clients) == 1
+        assert "test-token-123" in srv._slack_clients
+
+    def test_get_client_returns_cached(self, reset_slack_clients: None) -> None:
+        """Should return cached client for same token."""
+        # Call twice with same token
+        client1: AsyncWebClient = srv.get_slack_client("test-token-123")
+        client2: AsyncWebClient = srv.get_slack_client("test-token-123")
+        
+        # Should return the exact same object
+        assert client1 is client2
+        assert len(srv._slack_clients) == 1
+
+    def test_different_tokens_create_different_clients(self, reset_slack_clients: None) -> None:
+        """Should create different clients for different tokens."""
+        # Call with different tokens
+        client1: AsyncWebClient = srv.get_slack_client("token1")
+        client2: AsyncWebClient = srv.get_slack_client("token2")
+        
+        # Should be different objects with correct tokens
+        assert client1 is not client2
+        assert client1.token == "token1"
+        assert client2.token == "token2"
+        assert len(srv._slack_clients) == 2
+
+    def test_get_client_with_retry_uses_factory(self, reset_slack_clients: None, clean_env: None) -> None:
+        """Should use RetryableSlackClientFactory when retry count > 0."""
+        # Create a mock RetryableSlackClientFactory
+        mock_factory: MagicMock = MagicMock(spec=RetryableSlackClientFactory)
+        mock_client: MagicMock = MagicMock(spec=AsyncWebClient)
+        mock_factory.create_async_client.return_value = mock_client
+        
+        # Setup server module
+        srv._slack_client_retry_count = 5
+        srv._retryable_factory = mock_factory
+        
+        # Call get_slack_client
+        client: AsyncWebClient = srv.get_slack_client("test-token")
+        
+        # Verify factory was used
+        mock_factory.create_async_client.assert_called_once_with("test-token")
+        assert client is mock_client
+        assert "test-token" in srv._slack_clients
+
+    def test_get_client_from_env(self, reset_slack_clients: None, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Should fall back to environment variables when token is None."""
+        # Set environment variable 
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "env-token-123")
+        
+        # Update _DEFAULT_TOKEN which is calculated at module import time
+        srv._DEFAULT_TOKEN = "env-token-123"
+        
+        # Call get_slack_client with no token
+        client: AsyncWebClient = srv.get_slack_client()
+        
+        # Verify correct token was used
+        assert client.token == "env-token-123"
+        assert "env-token-123" in srv._slack_clients
+
+    def test_get_client_fallback_to_slack_token(
+        self, reset_slack_clients: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should try SLACK_TOKEN if SLACK_BOT_TOKEN is not set."""
+        # Set only SLACK_TOKEN
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        monkeypatch.setenv("SLACK_TOKEN", "fallback-token")
+        
+        # Directly set the cached token value
+        srv._DEFAULT_TOKEN = "fallback-token"
+        
+        # Call with no token
+        client: AsyncWebClient = srv.get_slack_client()
+        
+        # Verify correct token was used
+        assert client.token == "fallback-token"
+        assert "fallback-token" in srv._slack_clients
+
+    def test_get_client_no_token_raises_error(self, reset_slack_clients: None, clean_env: None) -> None:
+        """Should raise ValueError when no token is available."""
+        # Set _DEFAULT_TOKEN to None to simulate no env vars
+        srv._DEFAULT_TOKEN = None
+        
+        # Should raise ValueError
+        with pytest.raises(ValueError) as excinfo:
+            srv.get_slack_client()
+        
+        # Check error message
+        assert "Slack token not found" in str(excinfo.value)
+
+
+class TestClearSlackClients:
+    """Tests for clear_slack_clients function."""
+    
+    def test_clear_empty_cache(self, reset_slack_clients: None) -> None:
+        """Should handle clearing an already empty cache."""
+        # Start with empty cache
+        assert len(srv._slack_clients) == 0
+        
+        # Clear
+        srv.clear_slack_clients()
+        
+        # Still empty
+        assert len(srv._slack_clients) == 0
+
+    def test_clear_populated_cache(self, reset_slack_clients: None) -> None:
+        """Should clear all clients from cache."""
+        # Populate cache
+        srv._slack_clients["token1"] = AsyncWebClient(token="token1")
+        srv._slack_clients["token2"] = AsyncWebClient(token="token2")
+        assert len(srv._slack_clients) == 2
+        
+        # Clear
+        srv.clear_slack_clients()
+        
+        # Verify empty
+        assert len(srv._slack_clients) == 0
+
+    def test_clear_forces_new_clients(self, reset_slack_clients: None) -> None:
+        """Should force creation of new clients after clearing."""
+        # Create initial client
+        client1: AsyncWebClient = srv.get_slack_client("test-token")
+        
+        # Clear cache
+        srv.clear_slack_clients()
+        
+        # Get client again
+        client2: AsyncWebClient = srv.get_slack_client("test-token")
+        
+        # Should be different objects
+        assert client1 is not client2
+        assert client1.token == client2.token
+
+
+class TestUpdateSlackClient:
+    """Tests for update_slack_client function."""
+    
+    def test_update_new_client(self, reset_slack_clients: None) -> None:
+        """Should add a new client to the cache."""
+        # Create client
+        custom_client: AsyncWebClient = AsyncWebClient(token="custom-token")
+        
+        # Update cache
+        srv.update_slack_client("custom-token", custom_client)
+        
+        # Verify in cache
+        assert "custom-token" in srv._slack_clients
+        assert srv._slack_clients["custom-token"] is custom_client
+
+    def test_update_existing_client(self, reset_slack_clients: None) -> None:
+        """Should replace an existing client in the cache."""
+        # Add client to cache
+        original_client: AsyncWebClient = AsyncWebClient(token="test-token")
+        srv._slack_clients["test-token"] = original_client
+        
+        # Create replacement
+        replacement_client: AsyncWebClient = AsyncWebClient(token="test-token")
+        
+        # Update cache
+        srv.update_slack_client("test-token", replacement_client)
+        
+        # Verify replacement
+        assert srv._slack_clients["test-token"] is replacement_client
+        assert srv._slack_clients["test-token"] is not original_client
+
+    def test_update_with_empty_token_raises_error(self, reset_slack_clients: None) -> None:
+        """Should raise ValueError when token is empty."""
+        client: AsyncWebClient = AsyncWebClient(token="valid-token")
+        
+        # Empty string token
+        with pytest.raises(ValueError) as excinfo:
+            srv.update_slack_client("", client)
+        assert "Token cannot be empty" in str(excinfo.value)
+        
+        # None token
+        with pytest.raises(ValueError):
+            # We need to ignore the type error since we're testing runtime behavior
+            srv.update_slack_client(None, client)  # type: ignore
+
+
+class TestSetSlackClientRetryCount:
+    """Tests for set_slack_client_retry_count function."""
+
+    def test_set_retry_count(self, reset_slack_clients: None) -> None:
+        """Should update the retry count and factory."""
+        # Initial value
+        initial_count: int = srv._slack_client_retry_count
+        
+        # Set to new value
+        test_count: int = initial_count + 5  # Ensure different
+        srv.set_slack_client_retry_count(test_count)
+        
+        # Verify updated
+        assert srv._slack_client_retry_count == test_count
+        assert srv._retryable_factory.max_retry_count == test_count
+
+    def test_set_retry_clears_cache(self, reset_slack_clients: None) -> None:
+        """Should clear client cache when retry count is changed."""
+        # Populate cache
+        srv._slack_clients["token1"] = AsyncWebClient(token="token1")
+        srv._slack_clients["token2"] = AsyncWebClient(token="token2")
+        assert len(srv._slack_clients) == 2
+        
+        # Set retry count
+        srv.set_slack_client_retry_count(10)
+        
+        # Verify cache cleared
+        assert len(srv._slack_clients) == 0

--- a/test/unit_test/test_slack_server.py
+++ b/test/unit_test/test_slack_server.py
@@ -72,13 +72,13 @@ async def test_run_slack_server():
         await run_slack_server(host="localhost", port=8000, token="test_token")
 
         # Verify the app was created with the right token
-        mock_create_app.assert_called_once_with("test_token")
+        mock_create_app.assert_called_once_with("test_token", retry=3)
 
         # Verify the config was set correctly
         mock_config_cls.assert_called_once_with(app=mock_app, host="localhost", port=8000)
 
         # Verify the server was properly configured and started
-        mock_server_cls.assert_called_once_with(mock_config)
+        mock_server_cls.assert_called_once_with(config=mock_config)
         mock_server.serve.assert_called_once()
 
 
@@ -201,6 +201,7 @@ def test_main(
                 token=expected_token,
                 mcp_transport=expected_transport,
                 mcp_mount_path=expected_mount_path,
+                retry=3,  # Default retry value
             )
             mock_run_slack_server.assert_not_called()
         else:
@@ -208,6 +209,7 @@ def test_main(
                 host=expected_host,
                 port=expected_port,
                 token=expected_token,
+                retry=3,  # Default retry value
             )
             mock_run_integrated_server.assert_not_called()
 
@@ -269,11 +271,12 @@ async def test_run_integrated_server(host, port, token, mcp_transport, mcp_mount
             token=token,
             mcp_transport=mcp_transport,
             mcp_mount_path=mcp_mount_path,
+            retry=3,  # Default retry value
         )
 
         # Verify the config was set correctly
         mock_config_cls.assert_called_once_with(app=mock_app, host=host, port=port)
 
         # Verify the server was properly configured and started
-        mock_server_cls.assert_called_once_with(mock_config)
+        mock_server_cls.assert_called_once_with(config=mock_config)
         mock_server.serve.assert_called_once()


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Integrate to support the retry mechanism for the Slack operations into MCP and webhook servers

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86eu0bxyh
    * Relative task IDs:
        * N/A.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    N/A.


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Support new feature with some breaking changes


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Adjust to instantiate a general Slack web client instance or another one with retry mechanism at the initialing process of Slack web client instance.
* Integrate the new feature about retry mechanism into each 2 servers for MCP and webhook.
* Add new command line options *--retry* at the entry points of each 2 servers.
* Adjust the entry point shell scripts for Docker to support setting the new option *--retry*.
