### PR TITLE
[CU-86eu35015] Fix the broke reusable workflow of organizing test coverage reports

### DIFF
--- a/.github/workflows/rw_build_and_test.yaml
+++ b/.github/workflows/rw_build_and_test.yaml
@@ -82,7 +82,7 @@ jobs:
 #    name: For unit test, organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'|| (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: run_unit-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7.3
+    uses: ./.github/workflows/rw_organize_test_cov_reports.yaml
     with:
       test_type: unit-test
 
@@ -90,7 +90,7 @@ jobs:
 #    name: For unit test, organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'|| (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: run_integration-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7.3
+    uses: ./.github/workflows/rw_organize_test_cov_reports.yaml
     with:
       test_type: integration-test
 
@@ -98,7 +98,7 @@ jobs:
 #    name: For end-to-end test, organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'|| (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: run_e2e-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7.3
+    uses: ./.github/workflows/rw_organize_test_cov_reports.yaml
     with:
       test_type: e2e-test
 
@@ -106,7 +106,7 @@ jobs:
 #    name: For end-to-end test, organize and generate the testing report and upload it to Codecov
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'|| (github.event_name == 'push' && github.ref_name == 'master') }}
     needs: run_contract-test
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7.3
+    uses: ./.github/workflows/rw_organize_test_cov_reports.yaml
     with:
       test_type: contract-test
 
@@ -114,7 +114,7 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'|| (github.event_name == 'push' && github.ref_name == 'master')) && inputs.run_e2e == false }}
     needs: [run_unit-test, run_integration-test, run_contract-test]
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7.3
+    uses: ./.github/workflows/rw_organize_test_cov_reports.yaml
     with:
       test_type: all-test
 
@@ -122,6 +122,6 @@ jobs:
 #    name: Organize and generate the testing report and upload it to Codecov
     if: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'|| (github.event_name == 'push' && github.ref_name == 'master')) && inputs.run_e2e == true }}
     needs: [run_unit-test, run_integration-test, run_contract-test, run_e2e-test]
-    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@v7.3
+    uses: ./.github/workflows/rw_organize_test_cov_reports.yaml
     with:
       test_type: all-test

--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -1,0 +1,83 @@
+###################################################################################################################################
+#
+# Workflow Description:
+#     Organize all the testing coverage reports. (it would save reports by 'actions/upload-artifact').
+#
+# Workflow input parameters:
+#     * test_type: The testing type. In generally, it only has 2 options: 'unit-test' and 'integration-test'.
+#     * test_working_directory: The working directory for test running.
+#
+# Workflow running output:
+#     No, but it would save the testing coverage reports (coverage.xml) to provide after-process to organize and record.
+#
+#     * Upload-Artifact:
+#         * test_coverage_report: The handled test coverage report (.coverage file). It's file name format would be .coverage.<inputs.test type>.
+#         * test_coverage_xml_report: The handled test coverage report (.xml file). It's file name format would be coverage_<inputs.test type>.xml.
+#
+###################################################################################################################################
+
+name: Organize all testing coverage reports which be tested in many different runtime OS and Python version as a testing coverage report
+
+on:
+  workflow_call:
+    inputs:
+      test_type:
+        description: "The testing type. In generally, it only has 2 options: 'unit-test' and 'integration-test'."
+        type: string
+        required: true
+      test_working_directory:
+        description: "The working directory for test running."
+        required: false
+        type: string
+        default: './'
+
+
+jobs:
+  organize_and_generate_test_reports:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download code coverage result file
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage*
+          path: ${{ inputs.test_working_directory }}
+          merge-multiple: true
+
+      - name: Setup Python 3.12 in Ubuntu OS
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python tool 'coverage'
+        working-directory: ${{ inputs.test_working_directory }}
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install -U pip
+          pip3 install coverage
+          echo "======== Check all the test coverage reports currently. ========"
+          ls -la
+
+      - name: Combine all testing coverage data files with test type and runtime OS, and convert to XML format file finally
+        working-directory: ${{ inputs.test_working_directory }}
+        run: |
+          curl https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/develop/scripts/ci/combine_coverage_reports.sh --output ./scripts/ci/combine_coverage_reports.sh
+          bash ./scripts/ci/combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
+
+      - name: Upload testing coverage report (.coverage)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.test_type }}_coverage_data_file
+          path: ${{ inputs.test_working_directory }}.coverage
+          if-no-files-found: error
+          include-hidden-files: true
+
+      - name: Upload testing coverage report (.xml)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.test_type }}_coverage_xml_report
+          path: ${{ inputs.test_working_directory }}coverage**xml
+          if-no-files-found: error
+          include-hidden-files: true


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Fix the broke reusable workflow of organizing test coverage reports

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86eu35015
    * Relative task IDs:
        * N/A.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    N/A.


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Fix a bug of reusable workflow organizes test coverage reports


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Adjust to use Python 3.12 to organize test coverage reports to fix bugs.
