### PR TITLE
[MCP-1] ✨ feat: Add Socket Mode foundation and configuration support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,12 @@ SLACK_USER_TOKEN=xoxp-your-slack-user-token
 # Get it from: https://api.slack.com/apps → Your App → Basic Information
 SLACK_SIGNING_SECRET=<your-slack-signing-secret>
 
+# Slack app token (required for Socket Mode)
+# Format: xapp-... (app-level token)
+# Get it from: https://api.slack.com/apps -> Your App -> Basic Information -> App-Level Tokens
+# Required for Socket Mode to establish WebSocket connections
+SLACK_APP_TOKEN=xapp-your-slack-app-token
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Optional: Message Queue Backend Configuration
 # ─────────────────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ export SLACK_BOT_TOKEN="xoxb-your-bot-token-here"
 
 # Optional: For webhook server
 export SLACK_SIGNING_SECRET="your-signing-secret"
+
+# Optional: For Socket Mode transport
+export SLACK_APP_TOKEN="xapp-your-app-token-here"
 ```
 
 **For Testing:**
@@ -141,6 +144,9 @@ slack-mcp-server
 
 # Start with SSE transport for web clients
 slack-mcp-server --transport sse --host 0.0.0.0 --port 3001
+
+# Start with Socket Mode transport for WebSocket connections
+slack-mcp-server --transport socket-mode --app-token xapp-your-app-token
 ```
 
 #### 3. Start Webhook Server (Standalone)

--- a/slack_mcp/mcp/cli/models.py
+++ b/slack_mcp/mcp/cli/models.py
@@ -40,11 +40,13 @@ class MCPTransportType(str, Enum):
     - ``stdio``: Standard input/output transport
     - ``sse``: Server-Sent Events HTTP transport
     - ``streamable-http``: Streaming HTTP transport
+    - ``socket-mode``: WebSocket-based Socket Mode transport
     """
 
     STUDIO = "stdio"
     SSE = "sse"
     STREAMABLE_HTTP = "streamable-http"
+    SOCKET_MODE = "socket-mode"
 
 
 class MCPServerCliOptions(BaseModel):

--- a/slack_mcp/mcp/cli/models.py
+++ b/slack_mcp/mcp/cli/models.py
@@ -76,6 +76,8 @@ class MCPServerCliOptions(BaseModel):
         Disable loading .env file when True
     slack_token : str | None
         Slack bot token fallback (overridden by .env or environment)
+    app_token : str | None
+        Slack app token fallback for Socket Mode (overridden by .env or environment)
     integrated : bool
         Run in integrated mode with webhook server
     retry : int
@@ -104,6 +106,7 @@ class MCPServerCliOptions(BaseModel):
     env_file: str = ".env"
     no_env_file: bool = False
     slack_token: str | None = None
+    app_token: str | None = None
     integrated: bool = False
     retry: int = Field(3, ge=0)
 

--- a/slack_mcp/mcp/cli/options.py
+++ b/slack_mcp/mcp/cli/options.py
@@ -85,6 +85,11 @@ def _parse_args(argv: list[str] | None = None) -> MCPServerCliOptions:
         help="Slack bot token (fallback if not set in .env file or SLACK_BOT_TOKEN environment variable)",
     )
     parser.add_argument(
+        "--app-token",
+        default=None,
+        help="Slack app token for Socket Mode (fallback if not set in .env file or SLACK_APP_TOKEN environment variable)",
+    )
+    parser.add_argument(
         "--integrated",
         action="store_true",
         help="Run MCP server integrated with webhook server in a single FastAPI application",

--- a/slack_mcp/mcp/entry.py
+++ b/slack_mcp/mcp/entry.py
@@ -252,6 +252,8 @@ def main(argv: Optional[list[str]] = None) -> None:
     settings_kwargs = {}
     if args.slack_token:
         settings_kwargs["slack_bot_token"] = args.slack_token
+    if args.app_token:
+        settings_kwargs["slack_app_token"] = args.app_token
 
     # 2. Initialize SettingModel which will pick up values from .env file,
     # environment variables, and CLI fallbacks
@@ -266,6 +268,19 @@ def main(argv: Optional[list[str]] = None) -> None:
         settings = get_settings(
             env_file=args.env_file, no_env_file=args.no_env_file, force_reload=True, **settings_kwargs
         )
+
+        # Validate Socket Mode configuration
+        if args.transport == "socket-mode":
+            app_token = settings.slack_app_token
+            if not app_token:
+                _LOG.error("SLACK_APP_TOKEN is required for Socket Mode transport")
+                _LOG.error("Set it via environment variable, .env file, or --app-token CLI argument")
+                return
+            token_value = app_token.get_secret_value()
+            if not token_value.startswith("xapp-"):
+                _LOG.error(f"Invalid SLACK_APP_TOKEN format: {token_value[:8]}... (must start with 'xapp-')")
+                return
+            _LOG.info("Socket Mode configuration validated successfully")
     except Exception as e:
         _LOG.error(f"Failed to load configuration: {e}")
         return

--- a/slack_mcp/settings.py
+++ b/slack_mcp/settings.py
@@ -48,6 +48,9 @@ class SettingModel(BaseSettings):
         default=None, validation_alias=AliasChoices("SLACK_BOT_TOKEN", "SLACK_TOKEN", "E2E_TEST_API_TOKEN")
     )
     slack_user_token: Optional[SecretStr] = Field(default=None)
+    slack_app_token: Optional[SecretStr] = Field(
+        default=None, validation_alias=AliasChoices("SLACK_APP_TOKEN", "E2E_TEST_APP_TOKEN")
+    )
     slack_signing_secret: Optional[SecretStr] = Field(default=None)
 
     # Message queue backend settings

--- a/test/e2e_test/mcp/test_entry.py
+++ b/test/e2e_test/mcp/test_entry.py
@@ -435,3 +435,111 @@ def test_entry_dotenv_priority_over_cli(_patch_entry, monkeypatch: pytest.Monkey
     # Verify that get_settings was called with CLI token as kwargs
     # but the .env file (simulated in mock) would take priority
     # This tests the priority mechanism in pydantic-settings
+
+
+def test_entry_socket_mode_app_token_validation_success(_patch_entry, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test Socket Mode configuration validation with valid app token."""
+    entry = _patch_entry.entry
+
+    # Mock get_settings to return valid app token
+    with mock.patch("slack_mcp.mcp.entry.get_settings") as mock_get_settings:
+        mock_settings = mock.MagicMock()
+        mock_settings.slack_app_token.get_secret_value.return_value = "xapp-valid-token-123456"
+        mock_get_settings.return_value = mock_settings
+
+        # Test valid Socket Mode configuration
+        argv = ["--transport", "socket-mode", "--app-token", "xapp-valid-token-123456", "--no-env-file"]
+
+        def run_with_timeout() -> None:
+            entry.main(argv)
+
+        thread = threading.Thread(target=run_with_timeout)
+        thread.start()
+        thread.join(timeout=1)
+
+        # Verify get_settings was called with app_token
+        mock_get_settings.assert_called_with(
+            env_file=".env", no_env_file=True, force_reload=True, slack_app_token="xapp-valid-token-123456"
+        )
+
+
+def test_entry_socket_mode_missing_app_token(_patch_entry, monkeypatch: pytest.MonkeyPatch, caplog) -> None:
+    """Test Socket Mode configuration validation fails when app token is missing."""
+    entry = _patch_entry.entry
+
+    # Mock get_settings to return None for app token
+    with mock.patch("slack_mcp.mcp.entry.get_settings") as mock_get_settings:
+        mock_settings = mock.MagicMock()
+        mock_settings.slack_app_token = None
+        mock_get_settings.return_value = mock_settings
+
+        # Capture logs
+        caplog.set_level(logging.ERROR)
+
+        # Test Socket Mode without app token
+        argv = ["--transport", "socket-mode", "--no-env-file"]
+
+        def run_with_timeout() -> None:
+            entry.main(argv)
+
+        thread = threading.Thread(target=run_with_timeout)
+        thread.start()
+        thread.join(timeout=1)
+
+        # Verify error log was emitted about missing app token
+        assert "SLACK_APP_TOKEN is required for Socket Mode transport" in caplog.text
+
+
+def test_entry_socket_mode_invalid_app_token_format(_patch_entry, monkeypatch: pytest.MonkeyPatch, caplog) -> None:
+    """Test Socket Mode configuration validation fails with invalid app token format."""
+    entry = _patch_entry.entry
+
+    # Mock get_settings to return invalid app token format
+    with mock.patch("slack_mcp.mcp.entry.get_settings") as mock_get_settings:
+        mock_settings = mock.MagicMock()
+        mock_settings.slack_app_token.get_secret_value.return_value = "xoxb-invalid-bot-token"
+        mock_get_settings.return_value = mock_settings
+
+        # Capture logs
+        caplog.set_level(logging.ERROR)
+
+        # Test Socket Mode with invalid app token format
+        argv = ["--transport", "socket-mode", "--app-token", "xoxb-invalid-bot-token", "--no-env-file"]
+
+        def run_with_timeout() -> None:
+            entry.main(argv)
+
+        thread = threading.Thread(target=run_with_timeout)
+        thread.start()
+        thread.join(timeout=1)
+
+        # Verify error log was emitted about invalid token format
+        assert "Invalid SLACK_APP_TOKEN format" in caplog.text
+        assert "must start with 'xapp-'" in caplog.text
+
+
+def test_entry_app_token_from_cli(_patch_entry, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test setting app token from command line argument."""
+    entry = _patch_entry.entry
+
+    # Mock get_settings to track how it's called
+    with mock.patch("slack_mcp.mcp.entry.get_settings") as mock_get_settings:
+        mock_settings = mock.MagicMock()
+        mock_settings.slack_app_token.get_secret_value.return_value = "xapp-test-token-123456"
+        mock_get_settings.return_value = mock_settings
+
+        # Test app token provided via command line
+        test_app_token = "xapp-test-token-123456"
+        argv = ["--app-token", test_app_token, "--no-env-file"]
+
+        def run_with_timeout() -> None:
+            entry.main(argv)
+
+        thread = threading.Thread(target=run_with_timeout)
+        thread.start()
+        thread.join(timeout=1)
+
+        # Verify get_settings was called with the CLI app token as kwargs
+        mock_get_settings.assert_called_with(
+            env_file=".env", no_env_file=True, force_reload=True, slack_app_token=test_app_token
+        )


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

Add foundational support for Slack Socket Mode transport, including configuration management, CLI arguments, validation, and documentation.

* ### Task summary:

Implement Socket Mode transport configuration foundation for v0.3.0, enabling system administrators to configure Socket Mode without code changes and providing developers with clear documentation for setup.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90185744047/90184991515] which maps this change.)
* ### Task tickets:

    * Task ID: Feature 1: Socket Mode Transport Configuration
    * Relative task IDs:
        * [ ] Story 1: Configure Socket Mode connection settings as system administrator
        * [ ] Story 2: Validate Socket Mode configuration before startup
        * [ ] Story 3: Document Socket Mode environment variables for developers
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

**Configuration Management:**
- Added `slack_app_token` field to SettingModel with SecretStr validation
- Updated .env.example with SLACK_APP_TOKEN documentation
- Added SOCKET_MODE to MCPTransportType enum

**CLI Support:**
- Added `--app-token` CLI argument for Socket Mode app token
- Added app_token field to MCPServerCliOptions model
- Transport argument now accepts "socket-mode" value

**Validation Logic:**
- Added configuration validation for Socket Mode in entry point
- Validates app_token presence and format (must start with "xapp-")
- Provides clear error messages for invalid configuration

**Testing:**
- Added 4 unit tests for Socket Mode configuration validation
- Tests cover success case, missing token, invalid format, and CLI argument

**Documentation:**
- Updated README.md with Socket Mode setup instructions
- Added environment variable documentation for SLACK_APP_TOKEN
- Included Socket Mode transport usage examples


## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (maybe performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [x] ✍️ Command line interface
    * [x] 💼 Core feature
        * [ ] 🕸️ Web server
        * [x] 🤖 MCP server
        * [ ] 🪡 API client
        * [x] 🫀 Data model
    * [ ] 🎨 UI/UX (maybe command line interface, etc.)
    * [x] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
        * [ ] 🧪 Contract testing
    * [x] 📚 Documentation
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
* Additional description:
This is part 1 of 3 PRs for Socket Mode implementation. This PR establishes the foundation for Socket Mode configuration. No breaking changes - existing functionality remains unchanged. Socket Mode transport is now recognized but not yet implemented (will be in PR 2).


## _Description_

* This PR adds the foundational configuration and CLI support for Slack Socket Mode transport, enabling the system to recognize Socket Mode as a transport type and validate Socket Mode-specific configuration.

**Changes Made:**

1. **Settings Model** (`slack_mcp/settings.py`):
   - Added `slack_app_token: Optional[SecretStr]` field with validation alias for SLACK_APP_TOKEN environment variable

2. **Environment Configuration** (`.env.example`):
   - Added SLACK_APP_TOKEN documentation with format requirements (xapp- prefix)
   - Included setup instructions for obtaining app-level tokens

3. **CLI Models** (`slack_mcp/mcp/cli/models.py`):
   - Added `SOCKET_MODE = "socket-mode"` to MCPTransportType enum
   - Added `app_token: str | None` field to MCPServerCliOptions model
   - Updated documentation to include app_token field

4. **CLI Options** (`slack_mcp/mcp/cli/options.py`):
   - Added `--app-token` CLI argument for Socket Mode app token
   - Updated transport choices to include socket-mode (via enum update)

5. **Entry Point Validation** (`slack_mcp/mcp/entry.py`):
   - Added Socket Mode configuration validation logic
   - Validates app_token presence when transport is "socket-mode"
   - Validates app_token format (must start with "xapp-")
   - Provides clear error messages for invalid configuration
   - Passes app_token from CLI to settings model

6. **Unit Tests** (`test/e2e_test/mcp/test_entry.py`):
   - `test_entry_socket_mode_app_token_validation_success`: Tests valid Socket Mode configuration
   - `test_entry_socket_mode_missing_app_token`: Tests error handling for missing app token
   - `test_entry_socket_mode_invalid_app_token_format`: Tests error handling for invalid token format
   - `test_entry_app_token_from_cli`: Tests CLI argument handling for app token

7. **Documentation** (`README.md`):
   - Added SLACK_APP_TOKEN to environment variables section
   - Added Socket Mode transport usage example
   - Included setup instructions for Socket Mode

**Impact:**
- No breaking changes to existing functionality
- Socket Mode transport is now recognized but not yet implemented (will be in PR 2)
- Configuration validation prevents runtime errors for Socket Mode
- Clear documentation for users and developers

**Next Steps:**
- PR 2 will implement the actual WebSocket connection handling and event processing
- PR 3 will add integrated mode support, testing, and comprehensive documentation