### PR TITLE
🔧 ci: Add source_folder parameter for coverage path remapping

### DIFF
--- a/.github/workflows/rw_build_and_test.yaml
+++ b/.github/workflows/rw_build_and_test.yaml
@@ -98,6 +98,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: unit-test
+      source_folder: slack_mcp
 
   integration-test_codecov:
 #    name: For unit test, organize and generate the testing report and upload it to Codecov
@@ -109,6 +110,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: integration-test
+      source_folder: slack_mcp
 
   one_e2e-test_codecov:
 #    name: For end-to-end test, organize and generate the testing report and upload it to Codecov
@@ -120,6 +122,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: e2e-test
+      source_folder: slack_mcp
 
   e2e-test_codecov:
 #    name: For end-to-end test, organize and generate the testing report and upload it to Codecov
@@ -131,6 +134,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: e2e-test
+      source_folder: slack_mcp
 
   contract-test_codecov:
 #    name: For end-to-end test, organize and generate the testing report and upload it to Codecov
@@ -142,6 +146,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: contract-test
+      source_folder: slack_mcp
 
   all_test_codecov:
 #    name: Organize and generate the testing report and upload it to Codecov
@@ -153,3 +158,4 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
     with:
       test_type: all-test
+      source_folder: slack_mcp


### PR DESCRIPTION
## _Target_

Add `source_folder` parameter to coverage organization workflow to ensure correct path remapping for the `slack_mcp/` source folder.

* ### Task summary:

    The reusable workflow `rw_organize_test_cov_reports.yaml` now supports a configurable `source_folder` parameter. This update adds the parameter to all coverage organization jobs to correctly reference the `slack_mcp/` folder instead of the default `src/`.

* ### Task tickets:

    * Task ID: N/A.
    * Relative PRs:
        * Upstream: GitHub-Action_Reusable_Workflows-Python#156

* ### Key point change:

    **Before**:
    ```yaml
    uses: .../rw_organize_test_cov_reports.yaml@master
    with:
      test_type: unit-test
      # Missing source_folder - defaults to 'src/'
    ```
    
    **After**:
    ```yaml
    uses: .../rw_organize_test_cov_reports.yaml@master
    with:
      test_type: unit-test
      source_folder: slack_mcp  # ← Correctly references slack_mcp/
    ```

## _Effecting Scope_

* Action Types:
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 🚀 Building
        * [x] 🤖 CI/CD

## _Description_

### Changes Made:

Updated `.github/workflows/rw_build_and_test.yaml`:
- Added `source_folder: slack_mcp` to **unit-test_codecov** job
- Added `source_folder: slack_mcp` to **integration-test_codecov** job
- Added `source_folder: slack_mcp` to **one_e2e-test_codecov** job
- Added `source_folder: slack_mcp` to **e2e-test_codecov** job
- Added `source_folder: slack_mcp` to **contract-test_codecov** job
- Added `source_folder: slack_mcp` to **all_test_codecov** job

### Benefits:

✅ Correct coverage path mapping for `slack_mcp/` folder  
✅ Accurate coverage reports across macOS and Linux runners  
✅ Prevents "No source for code" errors in coverage reports